### PR TITLE
Fix bug of rerun not calculating columns that were never run

### DIFF
--- a/rh15d_mpi/distribute_jobs.c
+++ b/rh15d_mpi/distribute_jobs.c
@@ -84,7 +84,7 @@ void distribute_jobs(void)
 
     for (i = 0; i < mpi.nx; i++) {
       for (j = 0; j < mpi.ny; j++) {
-       if (mpi.rh_converged[i][j] < 1) remain_tasks++;
+       if (mpi.rh_converged[i][j] != 1) remain_tasks++;
       }
     }
 
@@ -147,10 +147,10 @@ long **get_taskmap(long remain_tasks, long *ntasks, long *my_start)
   k = 0;
   for (i=0; i < mpi.nx; i++) {
     for (j=0; j < mpi.ny; j++) {
-      if (mpi.rh_converged[i][j] < 1) {
-	taskmap[k][0] = i;
-	taskmap[k][1] = j;
-	++k;
+      if (mpi.rh_converged[i][j] != 1) {
+	       taskmap[k][0] = i;
+	       taskmap[k][1] = j;
+	       ++k;
       }
     }
   }


### PR DESCRIPTION
If RH is interrupted (ie, system problem), the convergence matrix in `output_indata.hdf5` (`mpi.convergence`) has a fill value of 9.96921e+36 for columns that were never run. In a re-run, these should be run anew, but after the change to HDF5 this no longer works. This PR should fix this bug.