### PR TITLE
Fixes #11, and corrects header for readInput

### DIFF
--- a/inputs.h
+++ b/inputs.h
@@ -122,7 +122,7 @@ int   getLine(FILE *inputFile, char *commentChar, char *line,
 int   getLineString(char **inputString, char *commentChar, char *line,
                     bool_t exit_on_EOF);
 void  parse(int argc, char *argv[], int Noption, Option *theOptions);
-void  readInput();
+void  readInput(char *input_string);
 void  readValues(char *fp_keyword, int Nkeyword, Keyword *theKeywords);
 
 char *readWholeFile(const char *filename);

--- a/rhf1d/backgrcontr.c
+++ b/rhf1d/backgrcontr.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
   setOptions(argc, argv);
   SetFPEtraps();
 
-  readInput();
+  readInput(NULL);
   MULTIatmos(&atmos, &geometry);
   readAtomicModels();
   readMolecularModels();

--- a/rhf1d/rhf1d.c
+++ b/rhf1d/rhf1d.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
   getCPU(0, TIME_START, NULL);
   SetFPEtraps();
 
-  readInput();
+  readInput(NULL);
   spectrum.updateJ = TRUE;
 
   getCPU(1, TIME_START, NULL);

--- a/rhf1d/solveray.c
+++ b/rhf1d/solveray.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 
   /* --- Read input data and initialize --             -------------- */
 
-  readInput();
+  readInput(NULL);
   spectrum.updateJ = FALSE;
 
   /* --- Read input data for atmosphere --             -------------- */

--- a/writeopac_xdr.c
+++ b/writeopac_xdr.c
@@ -71,7 +71,7 @@ void writeOpacity(void)
   xdrstdio_create(&xdrs, fp_out, XDR_ENCODE);
 
   if (atmos.moving || atmos.Stokes ||
-      (atmos.NPRDactive > 0 && input.PRD_angle_dep == PRD_ANGLE_DEP))
+      (atmos.NPRDactive > 0 && input.PRD_angle_dep != PRD_ANGLE_INDEP))
     Nrecord = atmos.Nrays*spectrum.Nspect;
   else
     Nrecord = spectrum.Nspect;


### PR DESCRIPTION
Now it isn't possible to call `readInput` without a pointer (can be `NULL`), as this was causing things to become confused.
A quick verification with `PRD_ANGLE_APPROX` and `PRD_ANGLE_DEP` has been undertaken.