### PR TITLE
Memory leak fixes as discussed in #9

### DIFF
--- a/background.c
+++ b/background.c
@@ -295,6 +295,10 @@ void Background(bool_t write_analyze_output, bool_t equilibria_only)
          a wavelength overlaps with a Bound-Bound transition in the
          background, or whether it is polarized --     -------------- */
 
+  if (atmos.backgrflags)
+  {
+    free(atmos.backgrflags);
+  }
   atmos.backgrflags = (flags *) malloc(spectrum.Nspect * sizeof(flags));
   for (nspect = 0;  nspect < spectrum.Nspect;  nspect++) {
     atmos.backgrflags[nspect].hasline = FALSE;
@@ -306,6 +310,10 @@ void Background(bool_t write_analyze_output, bool_t equilibria_only)
 
   backgrrecno = 0;
 
+  if (atmos.backgrrecno)
+  {
+    free(atmos.backgrrecno);
+  }
   if (atmos.moving || atmos.Stokes) {
     atmos.backgrrecno =
       (long *) malloc(2*spectrum.Nspect*atmos.Nrays * sizeof(long));
@@ -654,7 +662,7 @@ void Background(bool_t write_analyze_output, bool_t equilibria_only)
 	freeMolecule(&atmos.molecules[n]);
   }
 
-  if (strcmp(input.KuruczData, "none")) {
+  if (strcmp(input.KuruczData, "none") && input.solve_ne < ITERATION) {
     free(atmos.Tpf);  atmos.Tpf = NULL;
     for (n = 0;  n < atmos.Nelem;  n++) {
       free(atmos.elements[n].ionpot);

--- a/collision.c
+++ b/collision.c
@@ -486,12 +486,14 @@ void CollisionRate(struct Atom *atom, char *fp_atom)
   C0 = ((E_RYDBERG/sqrt(M_ELECTRON)) * PI*SQ(RBOHR)) *
     sqrt(8.0/(PI*KBOLTZMANN));
 
+  if (atom->C)
+    freeMatrix((void**)atom->C);
   atom->C = matrix_double(SQ(Nlevel), Nspace);
-  for (ij = 0;  ij < SQ(Nlevel);  ij++) {
-    for (k = 0;  k < Nspace;  k++) {
-      atom->C[ij][k] = 0.0;
-    }
-  }
+  // for (ij = 0;  ij < SQ(Nlevel);  ij++) {
+  //   for (k = 0;  k < Nspace;  k++) {
+  //     atom->C[ij][k] = 0.0;
+  //   }
+  // }
 
   //fgetpos(fp_atom, &collpos); //Tiago: not needed now
 

--- a/collision.c
+++ b/collision.c
@@ -489,13 +489,6 @@ void CollisionRate(struct Atom *atom, char *fp_atom)
   if (atom->C)
     freeMatrix((void**)atom->C);
   atom->C = matrix_double(SQ(Nlevel), Nspace);
-  // for (ij = 0;  ij < SQ(Nlevel);  ij++) {
-  //   for (k = 0;  k < Nspace;  k++) {
-  //     atom->C[ij][k] = 0.0;
-  //   }
-  // }
-
-  //fgetpos(fp_atom, &collpos); //Tiago: not needed now
 
   C = (double *) malloc(Nspace * sizeof(double));
 

--- a/getline.c
+++ b/getline.c
@@ -156,7 +156,7 @@ char *readWholeFile(const char *filename)
       sprintf(messageStr, "Error reading file %s", filename);
       Error(ERROR_LEVEL_2, routineName, filename);
   }
-  buffer = malloc(length);
+  buffer = (char*)malloc(length+1);
   if (buffer) {
       if (fread(buffer, 1, length, fp) < 1) {
           sprintf(messageStr, "Error reading file %s", filename);
@@ -167,6 +167,7 @@ char *readWholeFile(const char *filename)
       sprintf(messageStr, "Error closing file %s", filename);
       Error(ERROR_LEVEL_2, routineName, filename);
   }
+  buffer[length] = '\0';
   return buffer;
 }
 

--- a/profile.c
+++ b/profile.c
@@ -71,13 +71,14 @@ void Profile(AtomicLine *line)
 
   char    filename[MAX_LINE_SIZE];
   int     lamu, Nlamu, NrecStokes;
-  double *adamp = NULL, **v, **v_los, *vB, *sv, *vbroad, Larmor, H, F,
-          wlamu, vk, phi_pi, phi_sm, phi_sp, phi_delta, phi_sigma,
-          psi_pi, psi_sm, psi_sp, psi_delta, psi_sigma, sign, sin2_gamma,
-         *phi, *phi_Q, *phi_U, *phi_V, *psi_Q, *psi_U, *psi_V;
+  double *adamp = NULL, **v = NULL, **v_los = NULL, *vB = NULL, *sv = NULL, 
+         *vbroad = NULL, Larmor, H, F, wlamu, vk, phi_pi, phi_sm, phi_sp, 
+         phi_delta, phi_sigma, psi_pi, psi_sm, psi_sp, psi_delta, psi_sigma, 
+         sign, sin2_gamma, *phi = NULL, *phi_Q = NULL, *phi_U = NULL, 
+         *phi_V = NULL, *psi_Q = NULL, *psi_U = NULL, *psi_V = NULL;
 
   Atom *atom = line->atom;
-  ZeemanMultiplet *zm;
+  ZeemanMultiplet *zm = NULL;
 
   if (!line->Voigt) {
     sprintf(messageStr,
@@ -361,8 +362,9 @@ void Profile(AtomicLine *line)
   free(adamp);
   if (input.limit_memory) free(phi);
 
-  if (line->polarizable && (input.StokesMode > FIELD_FREE)) {
-    freeZeeman(zm);
+  if (atmos.moving || (line->polarizable && (input.StokesMode > FIELD_FREE))) {
+    if (zm)
+      freeZeeman(zm);
     free(zm);
     free(vB);
     free(sv);


### PR DESCRIPTION
Also adjusted file reading to be null-terminated so sgets doesn't read past the end of its buffer.
Valgrind reports this as leak-free even when run with `SOLVE_NE = ITERATION`.