### PR TITLE
Jaime branch

### DIFF
--- a/inputs.h
+++ b/inputs.h
@@ -112,6 +112,8 @@ typedef struct {
   char **kurucz_line_file_name;
   int Nkurucz_files;
   pthread_attr_t thread_attr;
+  // --- JdlCR, added a keyword to allow smoothing gradients in depth-optimization --- //
+  int wsize;
 } InputData;
 
 

--- a/readinput.c
+++ b/readinput.c
@@ -240,8 +240,8 @@ void readInput(char *input_string)
     {"15D_WRITE_TAU1", "FALSE",  FALSE, KEYWORD_OPTIONAL, &input.p15d_wtau,
      setboolValue},
     {"15D_WRITE_EXTRA",    "TRUE",  FALSE, KEYWORD_OPTIONAL, &input.p15d_wxtra,
-     setboolValue}
-
+     setboolValue},
+    {"15D_SMOOTH_OPTIMIZED_GRADIENTS", "0", FALSE, KEYWORD_OPTIONAL, &input.wsize, setintValue}
   };
   Nkeyword = sizeof(theKeywords) / sizeof(Keyword);
 

--- a/rh15d/run_example/keyword.input
+++ b/rh15d/run_example/keyword.input
@@ -13,11 +13,11 @@
   SNAPSHOT = 0
 
   X_START = 0
-  X_END   = 1 
+  X_END   = 0 
   X_STEP  = 1 
 
   Y_START = 0
-  Y_END   = 1
+  Y_END   = 0
   Y_STEP  = 1 
   
 # Runs only for non-converged columns (assumes output files already exist)
@@ -29,10 +29,11 @@
 # Cut the atmosphere above a certain TMAX?
   15D_DEPTH_ZCUT = TRUE
   15D_TMAX_CUT = 30000.
-
+  
 # Perform depth optimisation for each column (interpolates height scale)?
   15D_DEPTH_REFINE = FALSE
-
+  15D_SMOOTH_OPTIMIZED_GRADIENTS = 5
+  
 # Write level populations? (NLTE and LTE)
   15D_WRITE_POPS = FALSE
 


### PR DESCRIPTION
Having large velocity gradients in the atmosphere can induce large errors in Jmean. Typically when Vz changes per grid cell more than  the Doppler with of the line, errors will appear. I have added velocity gradients into the depth-optimization procedure. Also, sometimes the depth-optimization does not suffice to converge in some pixels. Smoothing the detected gradients in the optimization routine can help. I have added a new keyword in keyword.input called 15D_SMOOTH_OPTIMIZED_GRADIENTS=integer that defines the width of the smoothing window (zero by default).