### PR TITLE
free atmos->vturb when 15D_DEPTH_ZCUT = FALSE

### DIFF
--- a/rh15d/hdf5atmos.c
+++ b/rh15d/hdf5atmos.c
@@ -238,6 +238,10 @@ void readAtmos_hdf5(int xi, int yi, Atmosphere *atmos, Geometry *geometry,
     setTcut(atmos, geometry, input.p15d_tmax);
   } else {
     mpi.zcut = 0;
+    /*Free vturb in order to avoid successive addition of vturb_add. 
+      This is done in realloc_ndep (called by setTcut) if 15D_DEFINE_ZCUT = TRUE*/
+    free(atmos->vturb);
+    atmos->vturb  = (double *) calloc(atmos->Nspace , sizeof(double));
   }
 
   /* Memory dataspace, redefine for Nspace */


### PR DESCRIPTION
Currently, if 15D_DEPTH_ZCUT = FALSE, and vturb_add is used to define additional micorturbulence for line broadening, then each successive batch of columns has vturb_add continuously added to atmos->vturb because this is never freed in readAtmos_hdf5. This happens even for the first set of columns. So, if vturb_add = 10 km/s, then atmos->vturb = 20 km/s for the first batch of columns, atmos->vturb = 30 km/s for the next batch, etc., 

This is not a problem if  15D_DEPTH_ZCUT = TRUE, since atmos-vturb is freed in realloc_ndep, called by setTcut. 

I have added a statement to free atmos->vturb in readAtmos_hdf5 inside the conditional statements checking if setTcut should be called or not, which seems to fix the issue. 