### PR TITLE
Add output for collisional rates for all transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RH 1.5D
 =======
 
-[![DOI](https://zenodo.org/badge/16921006.svg)](https://zenodo.org/badge/latestdoi/16921006)
+[![Documentation Status](https://readthedocs.org/projects/rh15d/badge/?version=latest)](https://rh15d.readthedocs.io/en/latest/?badge=latest) [![DOI](https://zenodo.org/badge/16921006.svg)](https://zenodo.org/badge/latestdoi/16921006)
 
 RH 1.5D is an open source, massively-parallel radiative transfer code for spectral synthesis in stellar atmospheres. It is a modified version of the [RH code by Han Uitenbroek](http://www4.nso.edu/staff/uitenbr/rh.html).
 

--- a/doc/source/input.txt
+++ b/doc/source/input.txt
@@ -53,6 +53,9 @@ The new ``keyword.input`` options for the 1.5D version are:
 | ``15D_WRITE_RRATES``       | ``FALSE``          | If ``TRUE``, will write the radiative rates (lines and continua) for each        |
 |                            |                    | active atom to ``output_aux.hdf5``.                                              |
 +----------------------------+--------------------+----------------------------------------------------------------------------------+
+| ``15D_WRITE_CRATES``       | ``FALSE``          | If ``TRUE``, will write the collisional rates  for each  active atom to          |
+|                            |                    | ``output_aux.hdf5``.                                                             |
++----------------------------+--------------------+----------------------------------------------------------------------------------+
 | ``15D_WRITE_TAU1``         | ``FALSE``          | If ``TRUE``, will write the height of tau=1 to ``output_ray.hdf5``, for all      |
 |                            |                    | wavelengths (this takes up as much space as the intensity).                      |
 +----------------------------+--------------------+----------------------------------------------------------------------------------+

--- a/doc/source/output.txt
+++ b/doc/source/output.txt
@@ -64,23 +64,26 @@ The atom groups can contain the following optional variables:
 
 .. tabularcolumns:: |l|l|L|
 
-+---------------------+-------------------------------+------------------------------------+
-| Name                | Dimensions                    | Description                        |
-+=====================+===============================+====================================+
-| ``populations``     | ``(level, x, y, height)``     | Atomic populations.                |
-+---------------------+-------------------------------+------------------------------------+
-| ``populations_LTE`` | ``(level, x, y, height)``     | Atomic LTE populations.            |
-+---------------------+-------------------------------+------------------------------------+
-| ``Rij_line``        | ``(line, x, y, height)``      | Radiative rates out of the line.   |
-+---------------------+-------------------------------+------------------------------------+
-| ``Rji_line``        | ``(line, x, y, height)``      | Radiative rates into the line.     |
-+---------------------+-------------------------------+------------------------------------+
-| ``Rij_continuum``   | ``(continuum, x, y, height)`` | Radiative rates out of the         |
-|                     |                               | bf transition.                     |
-+---------------------+-------------------------------+------------------------------------+
-| ``Rji_continuum``   | ``(continuum, x, y, height)`` | Radiative rates into the bf        |
-|                     |                               | transition.                        |
-+---------------------+-------------------------------+------------------------------------+
++---------------------+---------------------------------+--------------------------------------+
+| Name                | Dimensions                      | Description                          |
++=====================+=================================+======================================+
+| ``populations``     | ``(level, x, y, height)``       | Atomic populations.                  |
++---------------------+---------------------------------+--------------------------------------+
+| ``populations_LTE`` | ``(level, x, y, height)``       | Atomic LTE populations.              |
++---------------------+---------------------------------+--------------------------------------+
+| ``Rij_line``        | ``(line, x, y, height)``        | Radiative rates out of the line.     |
++---------------------+---------------------------------+--------------------------------------+
+| ``Rji_line``        | ``(line, x, y, height)``        | Radiative rates into the line.       |
++---------------------+---------------------------------+--------------------------------------+
+| ``Rij_continuum``   | ``(continuum, x, y, height)``   | Radiative rates out of the           |
+|                     |                                 | bf transition.                       |
++---------------------+---------------------------------+--------------------------------------+
+| ``Rji_continuum``   | ``(continuum, x, y, height)``   | Radiative rates into the bf          |
+|                     |                                 | transition.                          |
++---------------------+---------------------------------+--------------------------------------+
+| ``collision_rates`` | ``(level, level, x, y, height)``| Collisional rates. Convention: first |
+|                     |                                 | index is upper level.                |
++---------------------+---------------------------------+--------------------------------------+
 
 The molecule groups can contain the following optional variables:
 

--- a/inputs.h
+++ b/inputs.h
@@ -102,7 +102,7 @@ typedef struct {
   int    Natoms;
   double p15d_tmax;
   bool_t p15d_wxtra, p15d_rerun, p15d_refine, p15d_zcut, p15d_wtau;
-  bool_t p15d_wpop, p15d_wrates;
+  bool_t p15d_wpop, p15d_wrates, p15d_wcrates;
   double iterLimit, PRDiterLimit, metallicity, *wavetable;
   unsigned int Nxwave;
   /* Tiago, for saving the input files */

--- a/readinput.c
+++ b/readinput.c
@@ -237,6 +237,8 @@ void readInput(char *input_string)
       setboolValue},
     {"15D_WRITE_RRATES", "FALSE",  FALSE, KEYWORD_OPTIONAL, &input.p15d_wrates,
       setboolValue},
+    {"15D_WRITE_CRATES", "FALSE",  FALSE, KEYWORD_OPTIONAL, &input.p15d_wcrates,
+      setboolValue},
     {"15D_WRITE_TAU1", "FALSE",  FALSE, KEYWORD_OPTIONAL, &input.p15d_wtau,
      setboolValue},
     {"15D_WRITE_EXTRA",    "TRUE",  FALSE, KEYWORD_OPTIONAL, &input.p15d_wxtra,

--- a/rh15d/io.h
+++ b/rh15d/io.h
@@ -121,10 +121,6 @@
 #define RJI_L_NAME  "Rji_line"
 #define RIJ_C_NAME  "Rij_continuum"
 #define RJI_C_NAME  "Rji_continuum"
-#define CIJ_L_NAME  "Cij_line"
-#define CJI_L_NAME  "Cji_line"
-#define CIJ_C_NAME  "Cij_continuum"
-#define CJI_C_NAME  "Cji_continuum"
 #define EM_NAME     "energy_matrix"
 #define COLL_NAME   "collision_rates"
 #define DAMP_NAME   "damping"
@@ -166,8 +162,7 @@ typedef struct {
   /* for the aux file */
   hid_t  aux_ncid,         *aux_atom_ncid,     aux_op_ncid,      *aux_atom_pop,
         *aux_atom_poplte,  *aux_atom_RijL,    *aux_atom_RjiL,    *aux_atom_RijC,
-        *aux_atom_RjiC,    *aux_atom_CijL,    *aux_atom_CjiL,    *aux_atom_CijC,
-        *aux_atom_CjiC,    *aux_atom_vbroad,  *aux_mol_ncid,     *aux_mol_pop,
+        *aux_atom_RjiC,    *aux_atom_vbroad,  *aux_mol_ncid,     *aux_mol_pop,
         *aux_mol_poplte,   *aux_mol_E,        *aux_mol_vbroad,   *aux_atom_Cij,
          aux_op_chi_ai,     aux_op_chi_ad,     aux_op_eta_ai,     aux_op_eta_ad;
   /* for atom file positions */
@@ -184,7 +179,7 @@ typedef struct {
 
 typedef struct {
   double  **n, **nstar, **nv, **nvstar;
-  double  **RijL, **RjiL, **RijC, **RjiC, **CijL, **CjiL, **CijC, **CjiC;
+  double  **RijL, **RjiL, **RijC, **RjiC;
   float   *J,  *J20;
 } IO_buffer;
 

--- a/rh15d/io.h
+++ b/rh15d/io.h
@@ -168,7 +168,7 @@ typedef struct {
         *aux_atom_poplte,  *aux_atom_RijL,    *aux_atom_RjiL,    *aux_atom_RijC,
         *aux_atom_RjiC,    *aux_atom_CijL,    *aux_atom_CjiL,    *aux_atom_CijC,
         *aux_atom_CjiC,    *aux_atom_vbroad,  *aux_mol_ncid,     *aux_mol_pop,
-        *aux_mol_poplte,   *aux_mol_E,        *aux_mol_vbroad,
+        *aux_mol_poplte,   *aux_mol_E,        *aux_mol_vbroad,   *aux_atom_Cij,
          aux_op_chi_ai,     aux_op_chi_ad,     aux_op_eta_ai,     aux_op_eta_ad;
   /* for atom file positions */
   long *atom_file_pos;

--- a/rh15d/parallel.c
+++ b/rh15d/parallel.c
@@ -465,7 +465,7 @@ void copyBufVars(bool_t writej) {
 /* Copies output variables to buffer arrays, to be written only at the end */
   const  char routineName[] = "copyBufVars";
   static long ind = 0;
-  int         i, ij, ji, ndep, nspect, nact, kr;
+  int         i, ndep, nspect, nact, kr;
   Atom       *atom;
   Molecule   *molecule;
   AtomicLine      *line;
@@ -496,20 +496,13 @@ void copyBufVars(bool_t writej) {
     memcpy((void *) &iobuf.nstar[nact][ind*atom->Nlevel], (void *) atom->nstar[0],
 	   atom->Nlevel * atmos.Nspace * sizeof(double));
 
-    /* Rij, Rji, Cij, Cji for lines */
+    /* Rij, Rji for lines */
     for (kr=0; kr < atom->Nline; kr++) {
       line = &atom->line[kr];
       memcpy((void *) &iobuf.RijL[nact][ind*atom->Nline + kr*atmos.Nspace],
 	     (void *) line->Rij, atmos.Nspace * sizeof(double));
       memcpy((void *) &iobuf.RjiL[nact][ind*atom->Nline + kr*atmos.Nspace],
 	     (void *) line->Rji, atmos.Nspace * sizeof(double));
-      /* Convention for output, Cij means transition i -> j */
-      ij = line->j * atom->Nlevel + line->i;
-      memcpy((void *) &iobuf.CijL[nact][ind*atom->Nline + kr*atmos.Nspace],
-	     (void *) atom->C[ij], atmos.Nspace * sizeof(double));
-      ji = line->i * atom->Nlevel + line->j;
-      memcpy((void *) &iobuf.CjiL[nact][ind*atom->Nline + kr*atmos.Nspace],
-	     (void *) atom->C[ji], atmos.Nspace * sizeof(double));
     }
 
     /* Rij, Rji for continua */
@@ -519,12 +512,6 @@ void copyBufVars(bool_t writej) {
 	     (void *) continuum->Rij, atmos.Nspace * sizeof(double));
       memcpy((void *) &iobuf.RjiC[nact][ind*atom->Ncont + kr*atmos.Nspace],
 	     (void *) continuum->Rji, atmos.Nspace * sizeof(double));
-      ij = continuum->j * atom->Nlevel + continuum->i;
-      memcpy((void *) &iobuf.CijC[nact][ind*atom->Ncont + kr*atmos.Nspace],
-	     (void *) atom->C[ij], atmos.Nspace * sizeof(double));
-      ji = continuum->i * atom->Nlevel + continuum->j;
-      memcpy((void *) &iobuf.CjiC[nact][ind*atom->Ncont + kr*atmos.Nspace],
-	     (void *) atom->C[ji], atmos.Nspace * sizeof(double));
     }
 
   }
@@ -579,10 +566,6 @@ void allocBufVars(bool_t writej) {
     iobuf.RjiL  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
     iobuf.RijC  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
     iobuf.RjiC  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
-    iobuf.CijL  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
-    iobuf.CjiL  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
-    iobuf.CijC  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
-    iobuf.CjiC  = (double **) malloc(atmos.Nactiveatom * sizeof(double *));
   }
 
   if (atmos.Nactivemol > 0) {
@@ -623,22 +606,6 @@ void allocBufVars(bool_t writej) {
     iobuf.RjiC[nact] = (double *) malloc(RCsize);
     if (iobuf.RjiC[nact] == NULL)
       Error(ERROR_LEVEL_2, routineName, "Out of memory\n");
-
-    iobuf.CijL[nact] = (double *) malloc(RLsize);
-    if (iobuf.CijL[nact] == NULL)
-      Error(ERROR_LEVEL_2, routineName, "Out of memory\n");
-
-    iobuf.CjiL[nact] = (double *) malloc(RLsize);
-    if (iobuf.CjiL[nact] == NULL)
-      Error(ERROR_LEVEL_2, routineName, "Out of memory\n");
-  
-    iobuf.CijC[nact] = (double *) malloc(RCsize);
-    if (iobuf.CijC[nact] == NULL)
-      Error(ERROR_LEVEL_2, routineName, "Out of memory\n");
-
-    iobuf.CjiC[nact] = (double *) malloc(RCsize);
-    if (iobuf.CjiC[nact] == NULL)
-      Error(ERROR_LEVEL_2, routineName, "Out of memory\n");
   }
 
   /* --- Loop over active MOLECULES --- */
@@ -675,10 +642,6 @@ void freeBufVars(bool_t writej) {
     free(iobuf.RjiL[nact]);
     free(iobuf.RijC[nact]);
     free(iobuf.RjiC[nact]);
-    free(iobuf.CijL[nact]);
-    free(iobuf.CjiL[nact]);
-    free(iobuf.CijC[nact]);
-    free(iobuf.CjiC[nact]);
   }
 
   free(iobuf.n);
@@ -687,10 +650,6 @@ void freeBufVars(bool_t writej) {
   free(iobuf.RjiL);
   free(iobuf.RijC);
   free(iobuf.RjiC);
-  free(iobuf.CijL);
-  free(iobuf.CjiL);
-  free(iobuf.CijC);
-  free(iobuf.CjiC);
 
   /* Loop over active MOLECULES */
   for (nact = 0;  nact < atmos.Nactivemol;  nact++) {

--- a/rh15d/run_example/keyword.input
+++ b/rh15d/run_example/keyword.input
@@ -39,6 +39,9 @@
 # Write radiative rates?
   15D_WRITE_RRATES = FALSE
 
+# Write collisional rates?
+  15D_WRITE_CRATES = FALSE
+
 # Value to add to supplied VTURB (in m/s)
   VTURB_ADD = 0.0
 

--- a/rh15d/writeAux_p.c
+++ b/rh15d/writeAux_p.c
@@ -71,7 +71,7 @@ void init_aux_new(void) {
   int       i;
   hid_t     plist, ncid, file_dspace, ncid_atom, ncid_mol;
   hid_t     id_x, id_y, id_z, id_n, id_tmp;
-  hsize_t   dims[4];
+  hsize_t   dims[5];
   char      group_name[ARR_STRLEN];
   Atom     *atom;
   Molecule *molecule;
@@ -116,6 +116,9 @@ void init_aux_new(void) {
       io.aux_atom_CjiL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_CijC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_CjiC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
+  }
+  if (input.p15d_wcrates) {
+      io.aux_atom_Cij    = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
   }
 
 
@@ -325,6 +328,30 @@ void init_aux_new(void) {
           if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
       }
     }
+    if (input.p15d_wcrates) {  
+      /* Collisional rates */
+      dims[0] = atom->Nlevel;
+      dims[1] = atom->Nlevel;
+      dims[2] = mpi.nx;
+      dims[3] = mpi.ny;
+      dims[4] = infile.nz;
+      if (( file_dspace = H5Screate_simple(5, dims, NULL) ) < 0) HERR(routineName);
+      if (( id_n = H5Dopen2(ncid_atom, LEVEL_NAME,
+                            H5P_DEFAULT)) < 0) HERR(routineName);
+      if (( id_tmp = H5Dcreate(ncid_atom, COLL_NAME, H5T_NATIVE_FLOAT,
+                               file_dspace, H5P_DEFAULT, plist,
+                               H5P_DEFAULT)) < 0) HERR(routineName);
+      if (( H5DSattach_scale(id_tmp, id_n, 0)) < 0) HERR(routineName);
+      if (( H5DSattach_scale(id_tmp, id_n, 1)) < 0) HERR(routineName);
+      if (( H5DSattach_scale(id_tmp, id_x, 2)) < 0) HERR(routineName);
+      if (( H5DSattach_scale(id_tmp, id_y, 3)) < 0) HERR(routineName);
+      if (( H5DSattach_scale(id_tmp, id_z, 4)) < 0) HERR(routineName);
+      if (( H5LTset_attribute_float(ncid_atom, COLL_NAME, "_FillValue",
+                                    &FILLVALUE, 1) ) < 0) HERR(routineName);
+      io.aux_atom_Cij[i] = id_tmp;
+      if (( H5Dclose(id_n) ) < 0) HERR(routineName);
+      if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
+    }
   if (( H5Dclose(id_x) ) < 0) HERR(routineName);
   if (( H5Dclose(id_y) ) < 0) HERR(routineName);
   if (( H5Dclose(id_z) ) < 0) HERR(routineName);
@@ -483,7 +510,9 @@ void init_aux_existing(void) {
       io.aux_atom_CijC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_CjiC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
   }
-
+  if (input.p15d_wcrates) {
+      io.aux_atom_Cij    = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
+  }
   /* --- Group loop over active ATOMS --- */
   for (i=0; i < atmos.Nactiveatom; i++) {
     atom = atmos.activeatoms[i];
@@ -546,6 +575,10 @@ void init_aux_existing(void) {
           if (( io.aux_atom_CjiC[i] = H5Dopen(ncid_atom, CJI_C_NAME,
                                          H5P_DEFAULT) )  < 0) HERR(routineName);
       }
+    }
+    if (input.p15d_wcrates) {
+      if (( io.aux_atom_Cij[i] = H5Dopen(ncid_atom, COLL_NAME,
+                                         H5P_DEFAULT) )  < 0) HERR(routineName);
     }
   } /* end active ATOMS loop */
 
@@ -626,6 +659,9 @@ void close_hdf5_aux(void)
           if (( H5Dclose(io.aux_atom_CjiC[i]) ) < 0) HERR(routineName);
       }
     }
+    if (input.p15d_wcrates) {
+      if (( H5Dclose(io.aux_atom_Cij[i]) ) < 0) HERR(routineName);
+    }
     if (( H5Gclose(io.aux_atom_ncid[i]) ) < 0) HERR(routineName);
   }
   for (i=0; i < atmos.Nactivemol; i++) {
@@ -657,6 +693,9 @@ void close_hdf5_aux(void)
     free(io.aux_atom_RjiC);
     free(io.aux_atom_CijC);
     free(io.aux_atom_CjiC);
+  }
+  if (input.p15d_wcrates) {
+    free(io.aux_atom_Cij);
   }
 
   return;
@@ -814,10 +853,11 @@ void writeAux_all(void) {
 void writeAux_p(void) {
   /* this will write: populations, radrates, coll, damping */
   const char routineName[] = "writeAux_p";
-  int      nact, kr, ji, ij;
-  hsize_t  offset[] = {0, 0, 0, 0};
-  hsize_t  count[] = {1, 1, 1, 1};
-  hsize_t  dims[4];
+  int      nact, kr, ji, ij, i, j, k, idx;
+  hsize_t  offset[] = {0, 0, 0, 0, 0};
+  hsize_t  count[] = {1, 1, 1, 1, 1};
+  hsize_t  dims[5];
+  double  *coll_rates;
   hid_t    file_dspace, mem_dspace;
   Atom      *atom;
   Molecule  *molecule;
@@ -895,6 +935,46 @@ void writeAux_p(void) {
       }
       if (( H5Sclose(mem_dspace) ) < 0) HERR(routineName);
       if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
+    }
+    if (input.p15d_wcrates) {
+      /* Write collisional rates */
+      coll_rates = (double *) calloc(SQ(atom->Nlevel) * atmos.Nspace, sizeof(double));
+      for (i=0; i < atom->Nlevel; i++) {
+        for (j=0; j < atom->Nlevel; j++) {
+          if (i != j) {
+            for (k=0; k < atmos.Nspace; k++) {
+              idx = (j * atom->Nlevel + i) * atmos.Nspace + k;
+              coll_rates[idx] = atom->C[j * atom->Nlevel + i][k];
+            }
+          }
+        }
+      }
+      /* Memory dataspace */
+      dims[0] = atom->Nlevel;
+      dims[1] = atom->Nlevel;
+      dims[2] = atmos.Nspace;
+      /* File dataspace */
+      offset[0] = 0;
+      offset[1] = 0;
+      offset[2] = mpi.ix;
+      offset[3] = mpi.iy;
+      offset[4] = mpi.zcut;
+      count[0] = atom->Nlevel;
+      count[1] = atom->Nlevel;
+      count[2] = 1;
+      count[3] = 1;
+      count[4] = atmos.Nspace;
+      if (( mem_dspace = H5Screate_simple(3, dims, NULL) ) < 0)
+          HERR(routineName);
+      if (( file_dspace = H5Dget_space(io.aux_atom_Cij[nact]) ) < 0)
+          HERR(routineName);
+      if (( H5Sselect_hyperslab(file_dspace, H5S_SELECT_SET, offset,
+                                NULL, count, NULL) ) < 0) HERR(routineName);
+      if (( H5Dwrite(io.aux_atom_Cij[nact], H5T_NATIVE_DOUBLE, mem_dspace,
+                   file_dspace, H5P_DEFAULT, coll_rates) ) < 0) HERR(routineName);
+      if (( H5Sclose(mem_dspace) ) < 0) HERR(routineName);
+      if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
+      free(coll_rates);
     }
   }
 

--- a/rh15d/writeAux_p.c
+++ b/rh15d/writeAux_p.c
@@ -112,10 +112,6 @@ void init_aux_new(void) {
       io.aux_atom_RjiL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_RijC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_RjiC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CijL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CjiL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CijC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CjiC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
   }
   if (input.p15d_wcrates) {
       io.aux_atom_Cij    = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
@@ -255,26 +251,6 @@ void init_aux_new(void) {
       if (( H5LTset_attribute_float(ncid_atom, RJI_L_NAME, "_FillValue",
                                     &FILLVALUE, 1) ) < 0) HERR(routineName);
       io.aux_atom_RjiL[i] = id_tmp;
-      if (( id_tmp = H5Dcreate(ncid_atom, CIJ_L_NAME, H5T_NATIVE_FLOAT,
-                               file_dspace, H5P_DEFAULT, plist,
-                               H5P_DEFAULT)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_n, 0)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_x, 1)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_y, 2)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_z, 3)) < 0) HERR(routineName);
-      if (( H5LTset_attribute_float(ncid_atom, CIJ_L_NAME, "_FillValue",
-                                    &FILLVALUE, 1) ) < 0) HERR(routineName);
-      io.aux_atom_CijL[i] = id_tmp;
-      if (( id_tmp = H5Dcreate(ncid_atom, CJI_L_NAME, H5T_NATIVE_FLOAT,
-                               file_dspace, H5P_DEFAULT, plist,
-                               H5P_DEFAULT)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_n, 0)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_x, 1)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_y, 2)) < 0) HERR(routineName);
-      if (( H5DSattach_scale(id_tmp, id_z, 3)) < 0) HERR(routineName);
-      if (( H5LTset_attribute_float(ncid_atom, CJI_L_NAME, "_FillValue",
-                                    &FILLVALUE, 1) ) < 0) HERR(routineName);
-      io.aux_atom_CjiL[i] = id_tmp;
       if (( H5Dclose(id_n) ) < 0) HERR(routineName);
       if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
       if (atom->Ncont > 0) {
@@ -303,27 +279,6 @@ void init_aux_new(void) {
           if (( H5LTset_attribute_float(ncid_atom, RJI_C_NAME, "_FillValue",
                                         &FILLVALUE, 1) ) < 0) HERR(routineName);
           io.aux_atom_RjiC[i] = id_tmp;
-          if (( id_tmp = H5Dcreate(ncid_atom, CIJ_C_NAME, H5T_NATIVE_FLOAT,
-                                  file_dspace, H5P_DEFAULT, plist,
-                                  H5P_DEFAULT)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_n, 0)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_x, 1)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_y, 2)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_z, 3)) < 0) HERR(routineName);
-          if (( H5LTset_attribute_float(ncid_atom, CIJ_C_NAME, "_FillValue",
-                                        &FILLVALUE, 1) ) < 0) HERR(routineName);
-          io.aux_atom_CijC[i] = id_tmp;
-          if (( id_tmp = H5Dcreate(ncid_atom, CJI_C_NAME, H5T_NATIVE_FLOAT,
-                                file_dspace, H5P_DEFAULT, plist,
-                                H5P_DEFAULT)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_n, 0)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_x, 1)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_y, 2)) < 0) HERR(routineName);
-          if (( H5DSattach_scale(id_tmp, id_z, 3)) < 0) HERR(routineName);
-          if (( H5LTset_attribute_float(ncid_atom, CJI_C_NAME, "_FillValue",
-                                        &FILLVALUE, 1) ) < 0) HERR(routineName);
-          io.aux_atom_CjiC[i] = id_tmp;
-
           if (( H5Dclose(id_n) ) < 0) HERR(routineName);
           if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
       }
@@ -505,10 +460,6 @@ void init_aux_existing(void) {
       io.aux_atom_RjiL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_RijC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
       io.aux_atom_RjiC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CijL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CjiL   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CijC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
-      io.aux_atom_CjiC   = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
   }
   if (input.p15d_wcrates) {
       io.aux_atom_Cij    = (hid_t *) malloc(atmos.Nactiveatom * sizeof(hid_t));
@@ -561,18 +512,10 @@ void init_aux_existing(void) {
                                          H5P_DEFAULT) )  < 0) HERR(routineName);
       if (( io.aux_atom_RjiL[i] = H5Dopen(ncid_atom, RJI_L_NAME,
                                          H5P_DEFAULT) )  < 0) HERR(routineName);
-      if (( io.aux_atom_CijL[i] = H5Dopen(ncid_atom, CIJ_L_NAME,
-                                         H5P_DEFAULT) )  < 0) HERR(routineName);
-      if (( io.aux_atom_CjiL[i] = H5Dopen(ncid_atom, CJI_L_NAME,
-                                         H5P_DEFAULT) )  < 0) HERR(routineName);
       if (atom->Ncont > 0) {
           if (( io.aux_atom_RijC[i] = H5Dopen(ncid_atom, RIJ_C_NAME,
                                          H5P_DEFAULT) )  < 0) HERR(routineName);
           if (( io.aux_atom_RjiC[i] = H5Dopen(ncid_atom, RJI_C_NAME,
-                                         H5P_DEFAULT) )  < 0) HERR(routineName);
-          if (( io.aux_atom_CijC[i] = H5Dopen(ncid_atom, CIJ_C_NAME,
-                                         H5P_DEFAULT) )  < 0) HERR(routineName);
-          if (( io.aux_atom_CjiC[i] = H5Dopen(ncid_atom, CJI_C_NAME,
                                          H5P_DEFAULT) )  < 0) HERR(routineName);
       }
     }
@@ -650,13 +593,9 @@ void close_hdf5_aux(void)
     if (input.p15d_wrates) {
       if (( H5Dclose(io.aux_atom_RijL[i]) ) < 0) HERR(routineName);
       if (( H5Dclose(io.aux_atom_RjiL[i]) ) < 0) HERR(routineName);
-      if (( H5Dclose(io.aux_atom_CijL[i]) ) < 0) HERR(routineName);
-      if (( H5Dclose(io.aux_atom_CjiL[i]) ) < 0) HERR(routineName);
       if (atom->Ncont > 0) {
           if (( H5Dclose(io.aux_atom_RijC[i]) ) < 0) HERR(routineName);
           if (( H5Dclose(io.aux_atom_RjiC[i]) ) < 0) HERR(routineName);
-          if (( H5Dclose(io.aux_atom_CijC[i]) ) < 0) HERR(routineName);
-          if (( H5Dclose(io.aux_atom_CjiC[i]) ) < 0) HERR(routineName);
       }
     }
     if (input.p15d_wcrates) {
@@ -687,12 +626,8 @@ void close_hdf5_aux(void)
   if (input.p15d_wrates) {
     free(io.aux_atom_RijL);
     free(io.aux_atom_RjiL);
-    free(io.aux_atom_CijL);
-    free(io.aux_atom_CjiL);
     free(io.aux_atom_RijC);
     free(io.aux_atom_RjiC);
-    free(io.aux_atom_CijC);
-    free(io.aux_atom_CjiC);
   }
   if (input.p15d_wcrates) {
     free(io.aux_atom_Cij);
@@ -766,12 +701,6 @@ void writeAux_all(void) {
         if (( H5Dwrite(io.aux_atom_RjiL[nact], H5T_NATIVE_DOUBLE,
                  mem_dspace, file_dspace, H5P_DEFAULT,
                  &iobuf.RjiL[nact][ind * atom->Nline]) ) < 0) HERR(routineName);
-        if (( H5Dwrite(io.aux_atom_CijL[nact], H5T_NATIVE_DOUBLE,
-                 mem_dspace, file_dspace, H5P_DEFAULT,
-                 &iobuf.CijL[nact][ind * atom->Nline]) ) < 0) HERR(routineName);
-        if (( H5Dwrite(io.aux_atom_CjiL[nact], H5T_NATIVE_DOUBLE,
-                 mem_dspace, file_dspace, H5P_DEFAULT,
-                 &iobuf.CjiL[nact][ind * atom->Nline]) ) < 0) HERR(routineName);
         /* release dataspace resources */
         if (( H5Sclose(mem_dspace) ) < 0) HERR(routineName);
         if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
@@ -792,12 +721,6 @@ void writeAux_all(void) {
             if (( H5Dwrite(io.aux_atom_RjiC[nact], H5T_NATIVE_DOUBLE,
                  mem_dspace, file_dspace, H5P_DEFAULT,
                  &iobuf.RjiC[nact][ind * atom->Ncont]) ) < 0) HERR(routineName);
-            if (( H5Dwrite(io.aux_atom_CijC[nact], H5T_NATIVE_DOUBLE,
-                 mem_dspace, file_dspace, H5P_DEFAULT,
-                 &iobuf.CijC[nact][ind * atom->Ncont]) ) < 0) HERR(routineName);
-            if (( H5Dwrite(io.aux_atom_CjiC[nact], H5T_NATIVE_DOUBLE,
-                 mem_dspace, file_dspace, H5P_DEFAULT,
-                 &iobuf.CjiC[nact][ind * atom->Ncont]) ) < 0) HERR(routineName);
             /* release dataspace resources */
             if (( H5Sclose(mem_dspace) ) < 0) HERR(routineName);
             if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
@@ -853,7 +776,7 @@ void writeAux_all(void) {
 void writeAux_p(void) {
   /* this will write: populations, radrates, coll, damping */
   const char routineName[] = "writeAux_p";
-  int      nact, kr, ji, ij, i, j, k, idx;
+  int      nact, kr, i, j, k, idx;
   hsize_t  offset[] = {0, 0, 0, 0, 0};
   hsize_t  count[] = {1, 1, 1, 1, 1};
   hsize_t  dims[5];
@@ -910,12 +833,6 @@ void writeAux_p(void) {
                   file_dspace, H5P_DEFAULT, line->Rij) ) < 0) HERR(routineName);
           if (( H5Dwrite(io.aux_atom_RjiL[nact], H5T_NATIVE_DOUBLE, mem_dspace,
                   file_dspace, H5P_DEFAULT, line->Rji) ) < 0) HERR(routineName);
-          ij = line->j * atom->Nlevel + line->i;
-          if (( H5Dwrite(io.aux_atom_CijL[nact], H5T_NATIVE_DOUBLE, mem_dspace,
-                  file_dspace, H5P_DEFAULT, atom->C[ij]) ) < 0) HERR(routineName);
-          ji = line->i * atom->Nlevel + line->j;
-          if (( H5Dwrite(io.aux_atom_CjiL[nact], H5T_NATIVE_DOUBLE, mem_dspace,
-                  file_dspace, H5P_DEFAULT, atom->C[ji]) ) < 0) HERR(routineName);
       }
       for (kr=0; kr < atom->Ncont; kr++) {
           offset[0] = kr;
@@ -926,18 +843,13 @@ void writeAux_p(void) {
              file_dspace, H5P_DEFAULT, continuum->Rij) ) < 0) HERR(routineName);
           if (( H5Dwrite(io.aux_atom_RjiC[nact], H5T_NATIVE_DOUBLE, mem_dspace,
              file_dspace, H5P_DEFAULT, continuum->Rji) ) < 0) HERR(routineName);
-          ij = continuum->j * atom->Nlevel + continuum->i;
-          if (( H5Dwrite(io.aux_atom_CijC[nact], H5T_NATIVE_DOUBLE, mem_dspace,
-             file_dspace, H5P_DEFAULT, atom->C[ij]) ) < 0) HERR(routineName);
-          ji = continuum->i * atom->Nlevel + continuum->j;
-          if (( H5Dwrite(io.aux_atom_CjiC[nact], H5T_NATIVE_DOUBLE, mem_dspace,
-             file_dspace, H5P_DEFAULT, atom->C[ji]) ) < 0) HERR(routineName);
       }
       if (( H5Sclose(mem_dspace) ) < 0) HERR(routineName);
       if (( H5Sclose(file_dspace) ) < 0) HERR(routineName);
     }
     if (input.p15d_wcrates) {
       /* Write collisional rates */
+      /* Copy data to better-aligned memory structure */
       coll_rates = (double *) calloc(SQ(atom->Nlevel) * atmos.Nspace, sizeof(double));
       for (i=0; i < atom->Nlevel; i++) {
         for (j=0; j < atom->Nlevel; j++) {

--- a/rh15d/writeAux_p.c
+++ b/rh15d/writeAux_p.c
@@ -800,6 +800,8 @@ void writeAux_p(void) {
     offset[2] = mpi.iy;
     offset[3] = mpi.zcut;
     count[0] = atom->Nlevel;
+    count[1] = 1;
+    count[2] = 1;
     count[3] = atmos.Nspace;
     if (input.p15d_wpop) {
       if (( mem_dspace = H5Screate_simple(2, dims, NULL) ) < 0)


### PR DESCRIPTION
Currently, collisional rates are only written for transitions with a radiative transition. The aim of this PR is to write them for all possible transitions. 