### PR TITLE
Fix Barklem broadening for Kurucz lines, add support for JJ and JK coupling

### DIFF
--- a/atom.h
+++ b/atom.h
@@ -2,7 +2,7 @@
 
        Version:       rh2.0
        Author:        Han Uitenbroek (huitenbroek@nso.edu)
-       Last modified: Mon Apr 18 06:31:57 2011 --
+       Last modified: Tue May 25 18:13:07 2021 --
 
        --------------------------                      ----------RH-- */
 
@@ -22,8 +22,6 @@
 #define PRD_QSPREAD 5.0
 #define PRD_DQ      0.25
 
-#define RLK_LABEL_LENGTH  10
-
 
 enum type        {ATOMIC_LINE, ATOMIC_CONTINUUM,
 		  VIBRATION_ROTATION, MOLECULAR_ELECTRONIC};
@@ -34,6 +32,7 @@ enum fit_type    {KURUCZ_70, KURUCZ_85, SAUVAL_TATUM_84, IRWIN_81, TSUJI_73};
 enum Hund        {CASE_A, CASE_B};
 enum Barklemtype {SP, PD, DF};
 enum orbit_am    {S_ORBIT=0, P_ORBIT, D_ORBIT, F_ORBIT};
+enum zeeman_cpl  {LS_COUPLING=0, JK_COUPLING, JJ_COUPLING};
 
 /* --- Structure prototypes --                         -------------- */
 
@@ -63,6 +62,7 @@ struct AtomicLine {
   Atom *atom;
   AtomicLine **xrd;
   pthread_mutex_t rate_lock;
+  ZeemanMultiplet *zm;
 };
 
 typedef struct {
@@ -158,19 +158,26 @@ struct Molecule {
 };
 
 typedef struct {
+  int    L, L1, l1, l2, l;
+  double g, E, S, J, S1, J1, j1, j2, K, gL, hfs;
+  enum zeeman_cpl cpl;
+  bool_t zm_explicit;
+} RLK_level;
+  
+typedef struct {
   bool_t polarizable;
   enum vdWaals vdwaals;
-  int    pt_index, stage, isotope, Li, Lj;
-  double lambda0, gi, gj, Ei, Ej, Bji, Aji, Bij, Si, Sj,
+  int    pt_index, stage, isotope;
+  double lambda0, Bji, Aji, Bij,
          Grad, GStark, GvdWaals, hyperfine_frac,
-         isotope_frac, gL_i, gL_j, hfs_i, hfs_j, iso_dl,
-         cross, alpha;
+         isotope_frac, iso_dl, cross, alpha;
+  RLK_level level_i, level_j;
   ZeemanMultiplet *zm;
 } RLK_Line;
 
 struct ZeemanMultiplet{
   int     Ncomponent, *q;
-  double *shift, *strength;
+  double *shift, *strength, g_eff;
 };
 
 typedef struct {
@@ -210,6 +217,10 @@ double getwlambda_cont(AtomicContinuum *continuum, int la);
 void initAtom(Atom *atom);
 void initAtomicLine(AtomicLine *line);
 void initAtomicContinuum(AtomicContinuum *continuum);
+
+void initZeeman(ZeemanMultiplet *zm);
+void freeZeeman(ZeemanMultiplet *zm);
+double zm_gamma(double J, double S, double L);
 
 void initGammaAtom(Atom *atom, double cswitch);
 void initGammaMolecule(Molecule *molecule);
@@ -287,9 +298,9 @@ bool_t determinate(char *label, double g, int *n, double *S, int *L,
 double effectiveLande(AtomicLine *line);
 double Lande(double S, int L, double J);
 void   StokesProfile(AtomicLine *line);
-ZeemanMultiplet* Zeeman(AtomicLine *line);
-ZeemanMultiplet* MolZeeman(MolecularLine *mrt);
-double           MolLande_eff(MolecularLine *mrt);
+void   Zeeman(AtomicLine *line);
+void   MolZeeman(MolecularLine *mrt);
+double MolLande_eff(MolecularLine *mrt);
 int    getOrbital(char orbit);
 double ZeemanStrength(double Ju, double Mu, double Jl, double Ml);
 

--- a/atom.h
+++ b/atom.h
@@ -158,7 +158,7 @@ struct Molecule {
 };
 
 typedef struct {
-  int    L, L1, l1, l2, l;
+  int    L, L1, l1, l2, l, L_ac;
   double g, E, S, J, S1, J1, j1, j2, K, gL, hfs;
   enum zeeman_cpl cpl;
   bool_t zm_explicit;

--- a/background.c
+++ b/background.c
@@ -190,6 +190,9 @@ void Background(bool_t write_analyze_output, bool_t equilibria_only)
   }
 
   getCPU(3, TIME_START, NULL);
+
+  do_fudge = FALSE;
+  
   if (strcmp(input.fudgeData, "none")) {
     do_fudge = TRUE;
 
@@ -216,8 +219,7 @@ void Background(bool_t write_analyze_output, bool_t equilibria_only)
     }
     for (n = 0;  n < 3*Nfudge;  n++) fudge[0][n] += 1.0;
     fclose(fp_fudge);
-  } else
-    do_fudge = FALSE;
+  }
 
   /* --- Allocate temporary storage space. The quantities are used
          for the following purposes:

--- a/barklem.c
+++ b/barklem.c
@@ -2,7 +2,7 @@
 
        Version:       rh2.0
        Author:        Han Uitenbroek (huitenbroek@nso.edu)
-       Last modified: Wed Nov 5, 2014, 15:24 --
+       Last modified: Fri May 14 19:18:30 2021 --
 
        --------------------------                      ----------RH-- */
 
@@ -173,9 +173,9 @@ bool_t getBarklemcross(Barklemstruct *bs, RLK_Line *rlk)
   if (rlk->stage > 0)
     return FALSE;
 
-  if ((deltaEi = element->ionpot[rlk->stage] - rlk->Ei) <= 0.0)
+  if ((deltaEi = element->ionpot[rlk->stage] - rlk->level_i.E) <= 0.0)
     return FALSE;
-  if ((deltaEj = element->ionpot[rlk->stage] - rlk->Ej) <= 0.0)
+  if ((deltaEj = element->ionpot[rlk->stage] - rlk->level_j.E) <= 0.0)
     return FALSE;
 
   Z = (double) (rlk->stage + 1);
@@ -183,8 +183,8 @@ bool_t getBarklemcross(Barklemstruct *bs, RLK_Line *rlk)
   neff1 = Z * sqrt(E_Rydberg / deltaEi);
   neff2 = Z * sqrt(E_Rydberg / deltaEj);
 
-  if (rlk->Li > rlk->Lj) SWAPDOUBLE(neff1, neff2);
-
+  if (rlk->level_i.L > rlk->level_j.L) SWAPDOUBLE(neff1, neff2);
+  
   if (neff1 < bs->neff1[0] || neff1 > bs->neff1[bs->N1-1])
     return FALSE;
   Locate(bs->N1, bs->neff1, neff1, &index);
@@ -203,7 +203,6 @@ bool_t getBarklemcross(Barklemstruct *bs, RLK_Line *rlk)
 			  bs->cross[0], findex2, findex1);
   rlk->alpha = cubeconvol(bs->N2, bs->N1,
 			  bs->alpha[0], findex2, findex1);
-
 
   reducedmass  = AMU / (1.0/atmos.H->weight + 1.0/element->weight);
   meanvelocity = sqrt(8.0 * KBOLTZMANN / (PI * reducedmass));

--- a/barklem.c
+++ b/barklem.c
@@ -183,7 +183,7 @@ bool_t getBarklemcross(Barklemstruct *bs, RLK_Line *rlk)
   neff1 = Z * sqrt(E_Rydberg / deltaEi);
   neff2 = Z * sqrt(E_Rydberg / deltaEj);
 
-  if (rlk->level_i.L > rlk->level_j.L) SWAPDOUBLE(neff1, neff2);
+  if (rlk->level_i.L_ac > rlk->level_j.L_ac) SWAPDOUBLE(neff1, neff2);
   
   if (neff1 < bs->neff1[0] || neff1 > bs->neff1[bs->N1-1])
     return FALSE;

--- a/collision.c
+++ b/collision.c
@@ -957,8 +957,6 @@ void CollisionRate(struct Atom *atom, char *fp_atom)
   free(T);
   free(coeff);
 
-  //fsetpos(fp_atom, &collpos);  // Tiago: not needed now (but when to free fp_atom?!)
-
   sprintf(labelStr, "Collision Rate %2s", atom->ID);
   getCPU(3, TIME_POLL, labelStr);
 }

--- a/fpehandler.c
+++ b/fpehandler.c
@@ -105,8 +105,8 @@ void SetFPEtraps(void)
   /* --- Enable some exceptions.
          At startup all exceptions are masked. --      -------------- */
 
-  /* Tiago: commented this out for the 1.5D version (where it should
-            not stop execution!)
+  /* Commented out for the 1.5D version, so it does not stop execution.
+  
      feenableexcept(FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW); */
 }
 

--- a/inputs.h
+++ b/inputs.h
@@ -78,7 +78,7 @@ typedef struct {
   bool_t magneto_optical, XRD, Eddington,
          backgr_pol, limit_memory, allow_passive_bb, NonICE,
          rlkscatter, prdh_limit_mem, backgr_in_mem, xdr_endian,
-         old_background, accelerate_mols;
+         old_background, accelerate_mols, RLK_explicit;
   enum   solution startJ;
   enum   StokesMode StokesMode;
   enum   S_interpol S_interpolation;

--- a/iterate.c
+++ b/iterate.c
@@ -56,8 +56,6 @@ void Iterate(int NmaxIter, double iterLimit)
   double dpopsmax, PRDiterlimit;
   Atom *atom;
   Molecule *molecule;
-  AtomicLine *line;        // Tiago: DELETE
-  int i, mu, to_obs, lamu; // Tiago: DELETE
 
   if (NmaxIter <= 0) return;
   getCPU(1, TIME_START, NULL);
@@ -119,9 +117,9 @@ void Iterate(int NmaxIter, double iterLimit)
       /* --- Redistribute intensity in PRD lines if necessary -- ---- */
 
       if (input.PRDiterLimit < 0.0)
-	PRDiterlimit = MAX(dpopsmax, -input.PRDiterLimit);
+      	PRDiterlimit = MAX(dpopsmax, -input.PRDiterLimit);
       else
-	PRDiterlimit = input.PRDiterLimit;
+      	PRDiterlimit = input.PRDiterLimit;
       Redistribute(input.PRD_NmaxIter, PRDiterlimit);
     }
 
@@ -146,45 +144,13 @@ void Iterate(int NmaxIter, double iterLimit)
 
     if (atmos.hydrostatic) {
       if (!atmos.atoms[0].active) {
-	sprintf(messageStr, "Can only perform hydrostatic equilibrium"
+      	sprintf(messageStr, "Can only perform hydrostatic equilibrium"
                             " for hydrogen active");
-	Error(ERROR_LEVEL_2, routineName, messageStr);
+	      Error(ERROR_LEVEL_2, routineName, messageStr);
       }
       Hydrostatic(N_MAX_HSE_ITER, HSE_ITER_LIMIT);
     }
   }
-
-      // Tiago: temporary printouts to get PRD rho after iteration
-      /*
-       atom = atmos.activeatoms[0];
-       line = &atom->line[0];
-
-       switch (input.PRD_angle_dep) {
-	case PRD_ANGLE_INDEP:
-	  printf("rho_prd = \n");
-	  for (i = 0; i < line->Nlambda; i++) {
-	    printf("%8.4f   %e   %e   %e   %e   %e\n", line->lambda[i], line->rho_prd[i][105], line->rho_prd[i][110], line->rho_prd[i][120], line->rho_prd[i][150], line->rho_prd[i][155]);
-	  }
-          //exit(1);
-	  break;
-
-	case PRD_ANGLE_DEP:
-	    for (mu = 0; mu < atmos.Nrays; mu++) {
-	      for (to_obs = 0; to_obs <= 1; to_obs++) {
-	       for (i = 0; i < line->Nlambda; i++) {
-		lamu = 2*(atmos.Nrays*i + mu) + to_obs;
-		if ((to_obs == 1) && (mu == 4))
-		printf("%8.4f  %e   %e   %e   %e   %e\n", line->lambda[i], line->rho_prd[lamu][105],line->rho_prd[lamu][110],line->rho_prd[lamu][120], line->rho_prd[lamu][150], line->rho_prd[lamu][155] );
-	      }
-	    }
-	  }
-	  //exit(1);
-          break;
-       }
-      */
-
-
-
 
   for (nact = 0;  nact < atmos.Nactiveatom;  nact++) {
     atom = atmos.activeatoms[nact];

--- a/ltepops.c
+++ b/ltepops.c
@@ -233,8 +233,6 @@ void SetLTEQuantities(void)
       /* --- Read the collisional data (in MULTI's GENCOL format).
              After this we can close the input file for the active
              atom. --                                  -------------- */
-      // Tiago: this must work with atom as string, must use
-      //        atom->offset_coll, and somehow read the file again! (filename gone)
       CollisionRate(atom, atom->offset_coll);
 
       /* --- Compute the fixed rates and store in Cij -- ------------ */

--- a/molzeeman.c
+++ b/molzeeman.c
@@ -2,7 +2,7 @@
 
        Version:       rh2.0
        Author:        Han Uitenbroek (huitenbroek@nso.edu)
-       Last modified: Thu Jun 30 15:35:10 2011 --
+       Last modified: Fri May 14 19:15:05 2021 --
 
        --------------------------                      ----------RH-- */
 
@@ -38,7 +38,7 @@ double MolZeemanStr(double Ju, double Mu, double Jl, double Ml)
   const char routineName[] = "MolZeemanStr";
 
   int    q, dJ;
-  double s;
+  double s = 0.0;
 
   /* --- Return the strength of Zeeman component (Ju, Mu) -> (Jl, Ml),
          where J and M are the total angular momentum and magnetic
@@ -195,7 +195,7 @@ double MolLande_eff(MolecularLine *mrt)
 
 /* ------- begin -------------------------- MolZeeman.c ------------- */
 
-ZeemanMultiplet* MolZeeman(MolecularLine *mrt)
+void MolZeeman(MolecularLine *mrt)
 {
   const char routineName[] = "MolZeeman";
 
@@ -221,7 +221,9 @@ ZeemanMultiplet* MolZeeman(MolecularLine *mrt)
 
 	 --                                            -------------- */
 
-  zm = (ZeemanMultiplet *) malloc(sizeof(ZeemanMultiplet));
+  mrt->zm = (ZeemanMultiplet *) malloc(sizeof(ZeemanMultiplet));
+  initZeeman(mrt->zm);
+  zm = mrt->zm;
 
   if (mrt->g_Lande_eff != 0.0) {
 
@@ -315,7 +317,5 @@ ZeemanMultiplet* MolZeeman(MolecularLine *mrt)
 	  "Zeeman components, gL_eff = %7.4f\n", mrt->molecule->ID,
 	  lambda_air, zm->Ncomponent, mrt->g_Lande_eff);
   Error(MESSAGE, routineName, messageStr);
-
-  return zm;
 }
-/* ------- end ---------------------------- Zeeman.c ---------------- */
+/* ------- end ------------------------- MolZeeman.c ---------------- */

--- a/opacity.c
+++ b/opacity.c
@@ -2,7 +2,7 @@
 
        Version:       rh2.0
        Author:        Han Uitenbroek (huitenbroek@nso.edu)
-       Last modified: Fri Jul 24 16:39:47 2009 --
+       Last modified: Fri May 14 17:53:23 2021 --
 
        --------------------------                      ----------RH-- */
 
@@ -444,9 +444,9 @@ void Opacity(int nspect, int mu, bool_t to_obs, bool_t initialize)
 
 void alloc_as(int nspect, bool_t crosscoupling)
 {
-  register int n, m, nact;
+  register int m, nact;
 
-  int i, j, NrecStokes, NrecStokes_as, Nactive, nt;
+  int i, j, NrecStokes, NrecStokes_as, nt;
   Atom *atom;
   Molecule *molecule;
   ActiveSet *as;
@@ -547,7 +547,7 @@ void alloc_as(int nspect, bool_t crosscoupling)
 
 void free_as(int nspect, bool_t crosscoupling)
 {
-  register int nact, n, m;
+  register int nact, m;
 
   int i, j, nt;
   Atom *atom;
@@ -582,23 +582,23 @@ void free_as(int nspect, bool_t crosscoupling)
       freeMatrix((void **) atom->rhth[nt].wla);
 
       if (crosscoupling) {
-	for (m = 0;  m < as->Nlower[nact];  m++) {
-	  i = as->lower_levels[nact][m];
-	  free(atom->rhth[nt].chi_up[i]);
-	  atom->rhth[nt].chi_up[i] = NULL;
-	}
-	free(atom->rhth[nt].chi_up);
+        for (m = 0;  m < as->Nlower[nact];  m++) {
+          i = as->lower_levels[nact][m];
+          free(atom->rhth[nt].chi_up[i]);
+          atom->rhth[nt].chi_up[i] = NULL;
+        }
+        free(atom->rhth[nt].chi_up);
 
-	for (m = 0;  m < as->Nupper[nact];  m++) {
-	  j = as->upper_levels[nact][m];
-	  free(atom->rhth[nt].chi_down[j]);
-	  free(atom->rhth[nt].Uji_down[j]);
+        for (m = 0;  m < as->Nupper[nact];  m++) {
+          j = as->upper_levels[nact][m];
+          free(atom->rhth[nt].chi_down[j]);
+          free(atom->rhth[nt].Uji_down[j]);
 
-	  atom->rhth[nt].chi_down[j] = NULL;
-	  atom->rhth[nt].Uji_down[j] = NULL;
-	}
-	free(atom->rhth[nt].chi_down);
-	free(atom->rhth[nt].Uji_down);
+          atom->rhth[nt].chi_down[j] = NULL;
+          atom->rhth[nt].Uji_down[j] = NULL;
+        }
+        free(atom->rhth[nt].chi_down);
+        free(atom->rhth[nt].Uji_down);
       }
     }
   }
@@ -663,16 +663,16 @@ bool_t containsBoundBound(ActiveSet *as)
 
 bool_t containsActive(ActiveSet *as)
 {
-  register int n, nact;
+  register int nact;
 
   for (nact = 0;  nact < atmos.Nactiveatom;  nact++) {
     if (as->Nactiveatomrt[nact] > 0)
-	return TRUE;
+	    return TRUE;
   }
 
   for (nact = 0;  nact < atmos.Nactivemol;  nact++) {
     if (as->Nactivemolrt[nact] > 0)
-	return TRUE;
+	    return TRUE;
   }
 
   return FALSE;
@@ -688,8 +688,8 @@ bool_t containsPRDline(ActiveSet *as)
   for (nact = 0;  nact < atmos.Nactiveatom;  nact++) {
     for (n = 0;  n < as->Nactiveatomrt[nact];  n++) {
       if (as->art[nact][n].type == ATOMIC_LINE &&
-	  as->art[nact][n].ptype.line->PRD) {
-	return TRUE;
+	        as->art[nact][n].ptype.line->PRD) {
+	      return TRUE;
       }
     }
   }
@@ -837,7 +837,7 @@ flags MolecularOpacity(double lambda, int nspect, int mu, bool_t to_obs,
 	    backgrflags.hasline = TRUE;
 	    if (mrt->polarizable) {
 	      backgrflags.ispolarized = TRUE;
-	      if (mrt->zm == NULL) mrt->zm = MolZeeman(mrt);
+	      if (mrt->zm == NULL) MolZeeman(mrt);
 	    }
 
 	    for (k = 0;  k < atmos.Nspace;  k++) {

--- a/readatom.c
+++ b/readatom.c
@@ -653,6 +653,7 @@ void initAtomicLine(AtomicLine *line)
   line->id0 = NULL;
   line->id1 = NULL;
   line->gII = NULL;
+  line->zm = NULL;
 }
 /* ------- end ---------------------------- initAtomicLine.c -------- */
 
@@ -732,6 +733,9 @@ void freeAtomicLine(AtomicLine *line)
     if (line->psi_Q != NULL) freeMatrix((void **) line->psi_Q);
     if (line->psi_U != NULL) freeMatrix((void **) line->psi_U);
     if (line->psi_V != NULL) freeMatrix((void **) line->psi_V);
+    if (atmos.Stokes &&	input.StokesMode == FULL_STOKES) {
+      if (line->zm != NULL)freeZeeman(line->zm);
+    }
   }
   if (line->c_shift != NULL)    free(line->c_shift);
   if (line->c_fraction != NULL) free(line->c_fraction);

--- a/readinput.c
+++ b/readinput.c
@@ -169,6 +169,9 @@ void readInput(char *input_string)
      &input.magneto_optical, setboolValue},
     {"BACKGROUND_POLARIZATION", "FALSE", FALSE, KEYWORD_DEFAULT,
      &input.backgr_pol, setboolValue},
+    {"RLK_EXPLICIT", "FALSE", FALSE, KEYWORD_DEFAULT,
+     &input.RLK_explicit, setboolValue},
+
     {"XDR_ENDIAN", "TRUE", FALSE, KEYWORD_OPTIONAL,
      &input.xdr_endian, setboolValue},
 
@@ -317,6 +320,9 @@ void readInput(char *input_string)
   /* --- Stokes for the moment only in 1D plane --     -------------- */
 
   if (strcmp(input.Stokes_input, "none")) {
+
+    /* --- Magnetic field is specified --              -------------- */
+
     switch (topology) {
     case ONE_D_PLANE:
     case TWO_D_PLANE:
@@ -354,6 +360,9 @@ void readInput(char *input_string)
 	    "Cannot accomodate magnetic fields in this topology");
     }
   } else {
+
+    /* --- No magnetic field input specified --        -------------- */
+    
     if (atmos.B_char != 0.0) {
       Error(WARNING, routineName,
 	    "Ignoring value of keyword B_STRENGTH_CHAR when no "

--- a/rh15d/iterate_p.c
+++ b/rh15d/iterate_p.c
@@ -141,7 +141,7 @@ void Iterate_p(int NmaxIter, double iterLimit)
     niter++;
     
     if (input.solve_ne == ITERATION)
-      Background(write_analyze_output=TRUE, equilibria_only=FALSE);
+      Background_p(write_analyze_output=TRUE, equilibria_only=FALSE);
     
     /* Update collisional radiative switching */
     if (input.crsw > 0)

--- a/rh15d/parallel.c
+++ b/rh15d/parallel.c
@@ -112,6 +112,7 @@ void initParallelIO(bool_t run_ray, bool_t writej) {
 
 /* ------- begin --------------------------  closeParallelIO.c    --- */
 void closeParallelIO(bool_t run_ray, bool_t writej) {
+  int i;
 
   if (!run_ray) {
     close_hdf5_indata();
@@ -128,6 +129,12 @@ void closeParallelIO(bool_t run_ray, bool_t writej) {
 
   /* Free buffer variables */
   freeBufVars(writej);
+
+  /* Free RLK stuff */
+  for (i = 0;  i < atmos.Nrlk;  i++) {
+    if (atmos.rlk_lines[i].zm != NULL) freeZeeman(atmos.rlk_lines[i].zm);
+  }
+  if (atmos.rlk_lines != NULL) free(atmos.rlk_lines); 
 }
 /* ------- end   --------------------------  closeParallelIO.c    --- */
 

--- a/rh15d/writeRay.c
+++ b/rh15d/writeRay.c
@@ -743,9 +743,7 @@ void calculate_ray(void) {
     if (input.prdh_limit_mem) prdh_limit_mem_save = TRUE;
     input.prdh_limit_mem = TRUE;
   }
-
   Background_p(analyze_output=FALSE, equilibria_only=FALSE);
-
   /* --- Solve radiative transfer for ray --           -------------- */
   solveSpectrum(FALSE, FALSE);
 

--- a/rh15d/writeRay.c
+++ b/rh15d/writeRay.c
@@ -656,14 +656,6 @@ void calculate_ray(void) {
   for (nact = 0; nact < atmos.Nactiveatom; nact++) {
     atom = atmos.activeatoms[nact];
 
-    // TIAGO: commented below
-    /* Rewind atom files to point just before collisional data
-    if ((ierror = fseek(atom->fp_input, io.atom_file_pos[nact], SEEK_SET))) {
-      sprintf(messageStr, "Unable to rewind atom file for %s", atom->ID);
-      Error(ERROR_LEVEL_2, "rh15d_ray", messageStr);
-    }
-    */
-
     /* Free collisions matrix, going to be re-allocated in background */
     if (atom->C != NULL) {
       freeMatrix((void **) atom->C);


### PR DESCRIPTION
Bring back some updates from Han for adding JJ and JK coupling in Zeeman computations, and fix the bug that does not read the proper orbital quantum number for to check if Barklem broadening can be used.