### PR TITLE
Remove call to StopRequested

### DIFF
--- a/rh15d/iterate_p.c
+++ b/rh15d/iterate_p.c
@@ -96,7 +96,7 @@ void Iterate_p(int NmaxIter, double iterLimit)
   else
     input.prdswitch = 1.0;
   
-  while (niter <= NmaxIter && !StopRequested()) {
+  while (niter <= NmaxIter) {
     getCPU(2, TIME_START, NULL);
 
     for (nact = 0;  nact < atmos.Nactiveatom;  nact++)


### PR DESCRIPTION
Remove call to StopRequested() in Iterate_p() to avoid excessive IO calls. This means that each process, at the start of each iteration, will try to open the same file.