### PR TITLE
Fix error when running with large N_MAX_ITER

### DIFF
--- a/rh15d/iterate_p.c
+++ b/rh15d/iterate_p.c
@@ -96,7 +96,7 @@ void Iterate_p(int NmaxIter, double iterLimit)
   else
     input.prdswitch = 1.0;
   
-  while (niter <= NmaxIter && !StopRequested()) {
+  while (niter <= NmaxIter) {
     getCPU(2, TIME_START, NULL);
 
     for (nact = 0;  nact < atmos.Nactiveatom;  nact++)


### PR DESCRIPTION
In `writeindata_p.c` there is a hardcoded value `NMaxIter = 1500`. if `N_MAX_ITER` is larger, an hdf5 error will occur. This PR modifies the hardcoded value to the value of `N_MAX_ITER` for new runs, and raises a more helpful error message in the case of reruns (when it is no longer possible to change the size of the array in `output_indata.hdf5`).