### PR TITLE
phi_V and psi_V are missing the isotopic fraction scaling

### DIFF
--- a/profile.c
+++ b/profile.c
@@ -291,7 +291,7 @@ void Profile(AtomicLine *line)
 		  phi_delta * sin2_gamma * atmos.cos_2chi[mu][k] * sv[k];
 		phi_U[k] +=
 		  phi_delta * sin2_gamma * atmos.sin_2chi[mu][k] * sv[k];
-		phi_V[k] += sign *
+		phi_V[k] += sign * line->c_fraction[n] *
 		  0.5*(phi_sp - phi_sm) * atmos.cos_gamma[mu][k] * sv[k];
 
 		if (input.magneto_optical) {
@@ -303,7 +303,7 @@ void Profile(AtomicLine *line)
 		    psi_delta * sin2_gamma * atmos.cos_2chi[mu][k] * sv[k];
 		  psi_U[k] +=
 		    psi_delta * sin2_gamma * atmos.sin_2chi[mu][k] * sv[k];
-		  psi_V[k] += sign *
+		  psi_V[k] += sign * line->c_fraction[n] * 
 		    0.5 * (psi_sp - psi_sm) * atmos.cos_gamma[mu][k] * sv[k];
 		}
 	      }


### PR DESCRIPTION
Hi Tiago,
the phi_V and psi_V are missing the isotopic fraction term. I have added it.
The other phi's and psi's include it through phi_sigma, phi_delta, psi_sigma and psi_delta.

Best regards,
Jaime